### PR TITLE
Explicitly require Stanza.js and Element.js

### DIFF
--- a/lib/StreamParser.js
+++ b/lib/StreamParser.js
@@ -3,9 +3,8 @@
 var inherits = require('inherits')
 var EventEmitter = require('events').EventEmitter
 var LtxParser = require('ltx/lib/parsers/ltx')
-var stanza = require('node-xmpp-stanza')
-var Stanza = stanza.Stanza
-var Element = stanza.Element
+var Stanza = require('node-xmpp-stanza/lib/Stanza')
+var Element = require('ltx/lib/Element')
 
 /**
  * Recognizes <stream:stream> and collects stanzas used for ordinary


### PR DESCRIPTION
Hello!

The project I'm working on is intended to work in browsers, so bundle size is important to me.

I use your (exellent) `StreamPasrer`, but unfortunalely it brings the whole [ltx](https://github.com/node-xmpp/ltx) package to my bundle with it.

This PR makes `StreamPasrer` require only files it actually needs, so in theory bundles should get a whole lot smaller.

I've also made a separate PR to `node-xmpp/stanza` to further reduce the bundle size.

---

Requiring files by path makes projects more fragile, but I guess it's fine as long as both projects are maintained by the same people. The better solution would be using [ES6 exports](https://github.com/rollup/rollup/wiki/jsnext:main), so bundlers like `rollup` or `webpack 2` could tree-shake the project to a minimal size. But it takes a bit more work than this, so I'll leave it to your consideration.